### PR TITLE
check for window.navigator for web-worker check

### DIFF
--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -117,6 +117,7 @@ export default class Auth0Client {
 
     // Don't use web workers unless using refresh tokens in memory and not IE11
     if (
+      window.navigator &&
       window.Worker &&
       this.options.useRefreshTokens &&
       this.cacheLocation === CACHE_LOCATION_MEMORY &&


### PR DESCRIPTION
This can solve issue - https://github.com/zeit/next.js/issues/11967#issuecomment-616383108 - This library otherwise errors out for SSR, even in limited use cases like Gatsby or Next.js